### PR TITLE
[bugfix] test_command_buffer.py 테스트 파일 위치를 CommandBufferFileManager 클…

### DIFF
--- a/tests/test_command_buffer.py
+++ b/tests/test_command_buffer.py
@@ -1,9 +1,8 @@
 import pytest
-from pathlib import Path
 
 from src.command_buffer.command_buffer_handler import CommandBufferHandler, CommandBufferHandlerException
 from src.command_buffer.command_buffer_data import ERASE, WRITE, EMPTY, ERASE_VALUE, WRITE_SIZE, CommandBufferDataException, CommandBufferData
-
+from src.command_buffer.command_buffer_file_manager import CommandBufferFileManager
 
 @pytest.fixture
 def command_buffer():
@@ -21,7 +20,7 @@ def test_initialize_성공(command_buffer):
 
 
 def test_command_buffers_객체_생성_성공_파일_없는_상태():
-    files_in_dir = [file for file in Path("../buffer").iterdir() if file.is_file()]
+    files_in_dir = [file for file in CommandBufferFileManager.COMMAND_BUFFER_DIR_PATH.iterdir() if file.is_file()]
     for file in files_in_dir:
         file.unlink(missing_ok=True)
 
@@ -70,27 +69,27 @@ def test_fast_Read_값이_없을_때(command_buffer):
     assert command_buffer.fast_read(4) is None
 
 def test_command_buffers_인자수_부족_2개미만(command_buffer):
-    files_in_dir = [file for file in Path("../buffer").iterdir() if file.is_file()]
-    files_in_dir[0].rename("../buffer/test")
+    files_in_dir = [file for file in CommandBufferFileManager.COMMAND_BUFFER_DIR_PATH.iterdir() if file.is_file()]
+    files_in_dir[0].rename(CommandBufferFileManager.COMMAND_BUFFER_DIR_PATH / 'test')
     with pytest.raises(CommandBufferDataException):
         new_command_buffer = CommandBufferHandler()
 
-    files_in_dir = [file for file in Path("../buffer").iterdir() if file.is_file()]
+    files_in_dir = [file for file in CommandBufferFileManager.COMMAND_BUFFER_DIR_PATH.iterdir() if file.is_file()]
     for file in files_in_dir:
         file.unlink(missing_ok=True)
 
 def test_command_buffers_WRITE_인자수_부족_4개_미만(command_buffer):
-    files_in_dir = [file for file in Path("../buffer").iterdir() if file.is_file()]
-    files_in_dir[0].rename("../buffer/1_W_3")
+    files_in_dir = [file for file in CommandBufferFileManager.COMMAND_BUFFER_DIR_PATH.iterdir() if file.is_file()]
+    files_in_dir[0].rename(CommandBufferFileManager.COMMAND_BUFFER_DIR_PATH / '1_W_3')
     with pytest.raises(CommandBufferDataException):
         new_command_buffer = CommandBufferHandler()
 
-    files_in_dir = [file for file in Path("../buffer").iterdir() if file.is_file()]
+    files_in_dir = [file for file in CommandBufferFileManager.COMMAND_BUFFER_DIR_PATH.iterdir() if file.is_file()]
     for file in files_in_dir:
         file.unlink(missing_ok=True)
 
 def test_command_buffers_fast_read_성공_파일_없는_상태():
-    files_in_dir = [file for file in Path("../buffer").iterdir() if file.is_file()]
+    files_in_dir = [file for file in CommandBufferFileManager.COMMAND_BUFFER_DIR_PATH.iterdir() if file.is_file()]
     for file in files_in_dir:
         file.unlink(missing_ok=True)
 


### PR DESCRIPTION
…래스에 대한 상대 참조로 변경

## 🚀 CleanCommit Pull Request

> **깨끗한 커밋과 동료를 존중하는 리뷰 문화를 지향합니다.**

### 📌 주요 변경 사항
* test_command_buffer.py 테스트 파일 위치를 CommandBufferFileManager 클래스에 대한 상대 참조로 변경

### 💡 리뷰어에게
* test pytest coverage 확인시 발생하는 에러를 개선 하였습니다.

---

### ✅ PR 생성 전 셀프 체크리스트
> PR을 올리기 전, 아래 항목을 모두 확인했나요?

#### ### 📜 **코드 컨벤션**
- [x] `Ctrl+Alt+L`을 이용해 코드를 포맷팅했나요?
- [x] 팀의 네이밍 컨벤션(변수, 메소드, 클래스 등)을 준수했나요?

#### ### ⚙️ **커밋 및 브랜치 전략**
- [x] 브랜치에 `feature/`, `bugfix/`, `refactor/` 와 같은 prefix를 사용했나요?
- [x] 커밋메시지에 `[Feature]`, `[Refactor]` 와 같은 prefix를 사용했나요?
- [x] 핵심 내용만 담아 의미 있는 단위로 커밋했나요?

#### ### ✅ **테스트 및 검증**
- [x] Self-review를 통해 유닛 테스트가 모두 통과하는 것을 확인했나요?

#### ### 🤝 **팀 워크플로우**
- [x] 작업 전 `git pull origin main`을 진행했으며, PR 생성 후 Discord에 공유했나요?
- **집중 리뷰**가 필요한 PR인가요? (필요 시 체크)
- [x] 16:30 이전 PR인가요? (이후는 다음 날 리뷰)

---

### 🙏 리뷰 감사합니다!

**Team. CleanCommit**
