### PR TITLE
[bugfix] Flush중 Erase Command에 대한 parameter를 value가 아닌 size를 사용하도록 변경

### DIFF
--- a/src/ssd_commands/ssd_flush.py
+++ b/src/ssd_commands/ssd_flush.py
@@ -18,7 +18,7 @@ class FlushSSDCommand(SSDCommand):
             if cmd.command_type == WRITE:
                 self._ssd_file_manager.write(cmd.lba, cmd.value)
             elif cmd.command_type == ERASE:
-                self._ssd_file_manager.erase(cmd.lba, cmd.value)
+                self._ssd_file_manager.erase(cmd.lba, cmd.size)
 
         self._command_buffer.initialize()
 


### PR DESCRIPTION
## 🚀 CleanCommit Pull Request

> **깨끗한 커밋과 동료를 존중하는 리뷰 문화를 지향합니다.**

### 📌 주요 변경 사항
* ssd_flush에서 발생하는 오류 수정 (value > size)

### 💡 리뷰어에게

---

### ✅ PR 생성 전 셀프 체크리스트
> PR을 올리기 전, 아래 항목을 모두 확인했나요?

#### ### 📜 **코드 컨벤션**
- [x] `Ctrl+Alt+L`을 이용해 코드를 포맷팅했나요?
- [x] 팀의 네이밍 컨벤션(변수, 메소드, 클래스 등)을 준수했나요?

#### ### ⚙️ **커밋 및 브랜치 전략**
- [x] 브랜치에 `feature/`, `bugfix/`, `refactor/` 와 같은 prefix를 사용했나요?
- [x] 커밋메시지에 `[Feature]`, `[Refactor]` 와 같은 prefix를 사용했나요?
- [x] 핵심 내용만 담아 의미 있는 단위로 커밋했나요?

#### ### ✅ **테스트 및 검증**
- [x] Self-review를 통해 유닛 테스트가 모두 통과하는 것을 확인했나요?

#### ### 🤝 **팀 워크플로우**
- [x] 작업 전 `git pull origin main`을 진행했으며, PR 생성 후 Discord에 공유했나요?
- [ ] **집중 리뷰**가 필요한 PR인가요? (필요 시 체크)
- [x] 16:30 이전 PR인가요? (이후는 다음 날 리뷰)

---

### 🙏 리뷰 감사합니다!

**Team. CleanCommit**
